### PR TITLE
Add map interactions with JWT

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,18 @@
-
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Mapa de Viajes</title>
+  <style>
+    .country { cursor: pointer; }
+    .visited { fill: green; }
+  </style>
+</head>
+<body>
+  <svg id="map" width="240" height="70">
+    <rect x="10" y="10" width="100" height="50" class="country" data-code="US" stroke="#000" fill="#ccc"></rect>
+    <rect x="120" y="10" width="100" height="50" class="country" data-code="MX" stroke="#000" fill="#ccc"></rect>
+  </svg>
+  <script src="public/js/map.js"></script>
+</body>
+</html>

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -1,0 +1,76 @@
+document.addEventListener('DOMContentLoaded', () => {
+  initMap();
+  loadTrips();
+});
+
+function getToken() {
+  return localStorage.getItem('token');
+}
+
+async function loadTrips() {
+  const token = getToken();
+  if (!token) {
+    showAuthError();
+    return;
+  }
+  try {
+    const resp = await fetch('/api/trips', {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    });
+    if (!resp.ok) {
+      if (resp.status === 401) showAuthError();
+      return;
+    }
+    const data = await resp.json();
+    const trips = Array.isArray(data.trips) ? data.trips : data;
+    if (Array.isArray(trips)) {
+      trips.forEach(colorCountry);
+    }
+  } catch (err) {
+    console.error('Failed to load trips', err);
+  }
+}
+
+function initMap() {
+  document.querySelectorAll('.country').forEach(el => {
+    el.addEventListener('click', () => selectCountry(el.dataset.code));
+  });
+}
+
+async function selectCountry(country_code) {
+  const token = getToken();
+  if (!token) {
+    showAuthError();
+    return;
+  }
+  try {
+    const resp = await fetch('/api/trips', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({ country_code })
+    });
+    if (!resp.ok) {
+      if (resp.status === 401) showAuthError();
+      return;
+    }
+    colorCountry(country_code);
+  } catch (err) {
+    console.error('Failed to save trip', err);
+  }
+}
+
+function colorCountry(code) {
+  const el = document.querySelector(`[data-code="${code}"]`);
+  if (el) {
+    el.classList.add('visited');
+  }
+}
+
+function showAuthError() {
+  alert('Tu sesión ha expirado o es inválida. Inicia sesión nuevamente.');
+}


### PR DESCRIPTION
## Summary
- Add map.js handling country selection and saved trip loading
- Include simple SVG map and script reference in index.html
- Show authentication error when JWT missing or expired

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c14356b4832b9abe49e03a015683