### PR TITLE
Add JWT auth and password hashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "prueba_codex",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "bcrypt": "^5.1.0",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.0"
+  }
+}

--- a/server/auth.js
+++ b/server/auth.js
@@ -1,0 +1,45 @@
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+
+const users = [];
+const SECRET_KEY = process.env.JWT_SECRET || 'secretkey';
+
+async function register(username, password) {
+  const hashedPassword = await bcrypt.hash(password, 10);
+  const user = { id: users.length + 1, username, password: hashedPassword };
+  users.push(user);
+  return { id: user.id, username: user.username };
+}
+
+async function login(username, password) {
+  const user = users.find(u => u.username === username);
+  if (!user) {
+    throw new Error('Invalid credentials');
+  }
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) {
+    throw new Error('Invalid credentials');
+  }
+  const token = jwt.sign({ id: user.id, username: user.username }, SECRET_KEY, { expiresIn: '1h' });
+  return token;
+}
+
+function verifyToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader) {
+    return res.status(401).json({ error: 'No token provided' });
+  }
+  const [scheme, token] = authHeader.split(' ');
+  if (scheme !== 'Bearer' || !token) {
+    return res.status(401).json({ error: 'Token malformado' });
+  }
+  jwt.verify(token, SECRET_KEY, (err, decoded) => {
+    if (err) {
+      return res.status(401).json({ error: 'Token inválido' });
+    }
+    req.user = decoded;
+    next();
+  });
+}
+
+module.exports = { register, login, verifyToken };

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const { register, login, verifyToken } = require('./auth');
+
+const app = express();
+app.use(express.json());
+
+app.post('/api/register', async (req, res) => {
+  const { username, password } = req.body;
+  try {
+    const user = await register(username, password);
+    res.status(201).json(user);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.post('/api/login', async (req, res) => {
+  const { username, password } = req.body;
+  try {
+    const token = await login(username, password);
+    res.json({ token });
+  } catch (err) {
+    res.status(401).json({ error: 'Credenciales inválidas' });
+  }
+});
+
+const trips = [
+  { id: 1, destination: 'Paris' },
+  { id: 2, destination: 'Tokyo' }
+];
+
+app.get('/api/trips', verifyToken, (req, res) => {
+  res.json(trips);
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- hash user passwords with bcrypt
- issue JWT tokens on login and secure `/api/trips` route
- define verifyToken middleware to gate map data

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm install express bcrypt jsonwebtoken` *(fails: 403 Forbidden for bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c1427c10832ba97325ebec30ca6a