### PR TITLE
Add Express server and Sequelize models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+database.sqlite

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "prueba_codex",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server/index.js",
+  "scripts": {
+    "start": "node server/index.js",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.19.2",
+    "sequelize": "^6.37.0",
+    "sqlite3": "^5.1.7"
+  }
+}

--- a/server/controllers/tripsController.js
+++ b/server/controllers/tripsController.js
@@ -1,0 +1,32 @@
+const { Trip } = require('../models');
+
+// Insert a new trip
+async function addTrip(req, res) {
+  const { userId, countryCode } = req.body;
+  try {
+    const trip = await Trip.create({ user_id: userId, country_code: countryCode });
+    res.json(trip);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+// Retrieve trips, optionally filtered by user
+async function getTrips(req, res) {
+  const { userId } = req.query;
+  const where = {};
+  if (userId) {
+    where.user_id = userId;
+  }
+  try {
+    const trips = await Trip.findAll({ where });
+    res.json(trips);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  addTrip,
+  getTrips,
+};

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const { sequelize, User } = require('./models');
+const { addTrip, getTrips } = require('./controllers/tripsController');
+
+const app = express();
+app.use(express.json());
+
+// Register user
+app.post('/api/register', async (req, res) => {
+  const { username, password } = req.body;
+  try {
+    const user = await User.create({ username, password });
+    res.json(user);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Login user
+app.post('/api/login', async (req, res) => {
+  const { username, password } = req.body;
+  try {
+    const user = await User.findOne({ where: { username, password } });
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    res.json({ message: 'Login successful' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Trips routes
+app.post('/api/trips', addTrip);
+app.get('/api/trips', getTrips);
+
+const PORT = process.env.PORT || 3000;
+sequelize.sync().then(() => {
+  app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+});

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,0 +1,45 @@
+const { Sequelize, DataTypes } = require('sequelize');
+
+// Initialize Sequelize with SQLite
+const sequelize = new Sequelize({
+  dialect: 'sqlite',
+  storage: 'database.sqlite',
+});
+
+// User model
+const User = sequelize.define('User', {
+  username: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    unique: true,
+  },
+  password: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+});
+
+// Trip model
+const Trip = sequelize.define('Trip', {
+  user_id: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: User,
+      key: 'id',
+    },
+  },
+  country_code: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+});
+
+User.hasMany(Trip, { foreignKey: 'user_id' });
+Trip.belongsTo(User, { foreignKey: 'user_id' });
+
+module.exports = {
+  sequelize,
+  User,
+  Trip,
+};


### PR DESCRIPTION
## Summary
- add SQLite-backed Sequelize models for users and trips
- implement Express server with registration, login, and trip routes
- create trip controller for inserting and querying trips

## Testing
- `npm test`
- `npm install express sequelize sqlite3` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c141cd74832b9ec09302afd8d5e0