### PR TITLE
Add Leaflet map with selectable countries

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mapa de Países</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-o9N1j7sPjH+J1qjOSAmhpN6wXNjZspGDf7vT2jnv6bU="
+      crossorigin=""
+    />
+    <style>
+        #map { height: 100vh; width: 100%; }
+    </style>
+</head>
+<body>
+    <div id="map"></div>
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-o9N1j7sPjH+J1qjOSAmhpN6wXNjZspGDf7vT2jnv6bU="
+      crossorigin=""
+    ></script>
+    <script src="js/map.js"></script>
+</body>
+</html>

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -1,0 +1,42 @@
+const map = L.map('map').setView([20, 0], 2);
+
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+const selectedCountries = [];
+
+function toggleCountry(e) {
+  const layer = e.target;
+  const code = layer.feature.properties.ISO_A3;
+  const index = selectedCountries.indexOf(code);
+
+  if (index === -1) {
+    selectedCountries.push(code);
+    layer.setStyle({ fillColor: '#3388ff', fillOpacity: 0.5 });
+  } else {
+    selectedCountries.splice(index, 1);
+    layer.setStyle({ fillOpacity: 0 });
+  }
+}
+
+function onEachFeature(feature, layer) {
+  layer.on({ click: toggleCountry });
+}
+
+fetch('https://raw.githubusercontent.com/datasets/geo-countries/master/data/countries.geojson')
+  .then((res) => res.json())
+  .then((data) => {
+    L.geoJSON(data, {
+      style: {
+        color: '#555',
+        weight: 1,
+        fillOpacity: 0,
+      },
+      onEachFeature,
+    }).addTo(map);
+  })
+  .catch((err) => console.error('Error loading GeoJSON', err));
+
+// Expose the selected countries array for later use
+window.getSelectedCountries = () => selectedCountries.slice();


### PR DESCRIPTION
## Summary
- add Leaflet map container and assets in public index
- initialize Leaflet map loading world GeoJSON and track selected ISO codes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c1412d58832b9e450675866dca4a