### PR TITLE
fix: load Leaflet correctly

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -41,11 +41,9 @@
 
   <script
     src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-    integrity="sha256-o9N1jJ/suVlTNh7I3ypzKCi632cWb2UXwE5ZkO0AD0A="
+    integrity="sha256-o9N1j7sPjH+J1qjOSAmhpN6wXNjZspGDf7vT2jnv6bU="
     crossorigin=""
   ></script>
-
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j7sPjH+J1qjOSAmhpN6wXNjZspGDf7vT2jnv6bU=" crossorigin=""></script>
 
   <script src="js/map.js"></script>
 </body>

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -56,6 +56,10 @@ function updateAuthUI() {
 
 function initMap() {
   map = L.map('map');
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+  }).addTo(map);
 
   fetch('data/countries.geojson')
     .then(res => res.json())


### PR DESCRIPTION
## Summary
- ensure Leaflet loads once with correct integrity hash so map initializes after login
- show OpenStreetMap tiles when the map initializes so the base map is visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1f5a1009c832bb2782727362e125a