### PR TITLE
Fix hidden map after login

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,8 +7,6 @@
   <link
     rel="stylesheet"
     href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-    integrity="sha256-sA+BxM6YrNipnTbBhO0fuC7vAXoTr4tkbk/AwZ7KjXo="
-    crossorigin=""
   />
   <link rel="stylesheet" href="css/style.css" />
 </head>
@@ -39,11 +37,7 @@
   </div>
   <div id="map" class="hidden"></div>
 
-  <script
-    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-    integrity="sha256-o9N1j7sPjH+J1qjOSAmhpN6wXNjZspGDf7vT2jnv6bU="
-    crossorigin=""
-  ></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
   <script src="js/map.js"></script>
 </body>

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -42,9 +42,11 @@ function updateAuthUI() {
     usernameSpan.textContent = username;
     if (!map) {
       initMap();
-    } else {
-      map.invalidateSize();
     }
+    // Leaflet needs a size recalculation after the map container becomes
+    // visible; delaying the call ensures the browser has rendered the
+    // element before Leaflet measures it.
+    setTimeout(() => map.invalidateSize(), 0);
     loadTrips();
   } else {
     authContainer.classList.remove('hidden');
@@ -55,7 +57,9 @@ function updateAuthUI() {
 }
 
 function initMap() {
-  map = L.map('map');
+  // Set a default view so the map is visible even if the GeoJSON data fails
+  // to load for some reason.
+  map = L.map('map').setView([20, 0], 2);
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'


### PR DESCRIPTION
## Summary
- Ensure Leaflet recalculates size after login so the map renders
- Set default world view in `initMap` to show map even if GeoJSON load fails
- Remove invalid Leaflet integrity attributes so resources load

## Testing
- `npm test`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68c2fa740a08832b9e064692d9d758e0