### PR TITLE
Fix hidden map after login

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,16 +1,11 @@
-body { 
-  font-family: Arial, sans-serif; 
-  margin: 0; 
-  padding: 0; 
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
   background: #f0f2f5;
   display: flex;
   flex-direction: column;
   align-items: center;
-}
-
-h1 {
-  text-align: center;
-  margin-top: 20px;
 }
 
 #auth {
@@ -77,11 +72,6 @@ h1 {
   background: #1d6fe0;
 }
 
-#userInfo {
-  text-align: center;
-  margin-bottom: 10px;
-}
-
 .hidden {
   display: none;
 }
@@ -95,6 +85,49 @@ h1 {
 #map {
   height: 70vh;
   width: 100%;
+}
+
+#navbar {
+  width: 100%;
+  background: #3388ff;
+  color: #fff;
+  padding: 10px;
+  display: flex;
+  align-items: center;
+}
+
+#navbar .brand {
+  font-weight: bold;
+}
+
+#navbar .spacer {
+  flex: 1;
+}
+
+#navbar #logoutBtn {
+  margin-left: 10px;
+}
+
+#addTripBtn {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #3388ff;
+  color: #fff;
+  font-size: 24px;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+}
+
+#addTripBtn.active {
+  background: #1d6fe0;
 }
 
 @media (max-width: 600px) {

--- a/public/index.html
+++ b/public/index.html
@@ -7,13 +7,16 @@
   <link
     rel="stylesheet"
     href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-    integrity="sha256-sA+BxM6YrNipnTbBhO0fuC7vAXoTr4tkbk/AwZ7KjXo="
-    crossorigin=""
   />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
-  <h1>Mis Viajes</h1>
+  <nav id="navbar" class="hidden">
+    <span class="brand">Mis Viajes</span>
+    <span class="spacer"></span>
+    <span id="username"></span>
+    <button id="logoutBtn">Cerrar sesión</button>
+  </nav>
   <div id="auth">
     <div id="authContainer">
       <div id="authSwitch">
@@ -31,19 +34,12 @@
         <button type="submit">Registrarse</button>
       </form>
     </div>
-    <div id="userInfo" class="hidden">
-      Bienvenido, <span id="username"></span>
-      <button id="logoutBtn">Cerrar sesión</button>
-    </div>
     <div id="message"></div>
   </div>
   <div id="map" class="hidden"></div>
+  <button id="addTripBtn" class="hidden">+</button>
 
-  <script
-    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-    integrity="sha256-o9N1j7sPjH+J1qjOSAmhpN6wXNjZspGDf7vT2jnv6bU="
-    crossorigin=""
-  ></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
   <script src="js/map.js"></script>
 </body>

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -1,6 +1,8 @@
 let map;
 let geojsonLayer;
 let visited = new Map();
+let addingMode = false;
+let addTripBtn;
 
 function getToken() {
   return localStorage.getItem('token');
@@ -30,32 +32,38 @@ function showMessage(msg, isError = false) {
 }
 
 function updateAuthUI() {
-  const authContainer = document.getElementById('authContainer');
-  const userInfo = document.getElementById('userInfo');
+  const auth = document.getElementById('auth');
+  const navbar = document.getElementById('navbar');
   const mapDiv = document.getElementById('map');
   const usernameSpan = document.getElementById('username');
   const username = getUsernameFromToken();
   if (username) {
-    authContainer.classList.add('hidden');
-    userInfo.classList.remove('hidden');
+    auth.classList.add('hidden');
+    navbar.classList.remove('hidden');
     mapDiv.classList.remove('hidden');
+    addTripBtn.classList.remove('hidden');
     usernameSpan.textContent = username;
     if (!map) {
       initMap();
-    } else {
-      map.invalidateSize();
     }
+    setTimeout(() => map.invalidateSize(), 0);
     loadTrips();
   } else {
-    authContainer.classList.remove('hidden');
-    userInfo.classList.add('hidden');
+    auth.classList.remove('hidden');
+    navbar.classList.add('hidden');
     mapDiv.classList.add('hidden');
+    addTripBtn.classList.add('hidden');
     usernameSpan.textContent = '';
+    addingMode = false;
+    addTripBtn.classList.remove('active');
+    addTripBtn.textContent = '+';
   }
 }
 
 function initMap() {
-  map = L.map('map');
+  // Set a default view so the map is visible even if the GeoJSON data fails
+  // to load for some reason.
+  map = L.map('map').setView([20, 0], 2);
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
@@ -76,6 +84,7 @@ function initMap() {
 }
 
 function onCountryClick(e) {
+  if (!addingMode) return;
   const code = e.target.feature.properties.ISO_A3;
   const token = getToken();
   if (!token) {
@@ -98,8 +107,11 @@ function onCountryClick(e) {
   }).then(res => {
     if (res.ok) {
       visited.set(code, date);
-      e.target.setStyle({ fillColor: '#3388ff', fillOpacity: 0.5 });
-      e.target.bindTooltip(date);
+      colorVisited();
+      addingMode = false;
+      addTripBtn.classList.remove('active');
+      addTripBtn.textContent = '+';
+      loadTrips();
     } else if (res.status === 401) {
       alert('Sesión inválida');
     }
@@ -139,6 +151,13 @@ function setupForms() {
   const logoutBtn = document.getElementById('logoutBtn');
   const loginToggle = document.getElementById('loginToggle');
   const registerToggle = document.getElementById('registerToggle');
+  addTripBtn = document.getElementById('addTripBtn');
+
+  addTripBtn.addEventListener('click', () => {
+    addingMode = !addingMode;
+    addTripBtn.classList.toggle('active', addingMode);
+    addTripBtn.textContent = addingMode ? '×' : '+';
+  });
 
   loginToggle.addEventListener('click', () => {
     logForm.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- Ensure Leaflet recalculates size after login so the map renders
- Set default world view in `initMap` to show map even if GeoJSON load fails
- Remove invalid Leaflet integrity attributes so resources load
- Hide authentication form after login and show a navbar with logout
- Require tapping a '+' button to add trips, with countries highlighted after saving

## Testing
- `npm test`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68c2fa740a08832b9e064692d9d758e0