### PR TITLE
Validate credentials for user registration and login

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -10,12 +10,22 @@ function hashPassword(password) {
 }
 
 async function register(username, password) {
+  if (!username || !password) {
+    throw new Error('Missing credentials');
+  }
+  const existing = await User.findOne({ where: { username } });
+  if (existing) {
+    throw new Error('User already exists');
+  }
   const password_hash = hashPassword(password);
   const user = await User.create({ username, password_hash });
   return { id: user.id, username: user.username };
 }
 
 async function login(username, password) {
+  if (!username || !password) {
+    throw new Error('Missing credentials');
+  }
   const user = await User.findOne({ where: { username } });
   if (!user) {
     throw new Error('Invalid credentials');

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,9 @@ app.use(express.static('public'));
 
 app.post('/api/register', async (req, res) => {
   const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Faltan datos' });
+  }
   try {
     const user = await register(username, password);
     res.status(201).json(user);
@@ -19,6 +22,9 @@ app.post('/api/register', async (req, res) => {
 
 app.post('/api/login', async (req, res) => {
   const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Faltan datos' });
+  }
   try {
     const token = await login(username, password);
     res.json({ token });


### PR DESCRIPTION
## Summary
- Validate username and password presence when registering and logging in
- Return consistent error messages for missing data
- Reject duplicate usernames during registration

## Testing
- `npm test`
- `curl -s -X POST -H "Content-Type: application/json" -d '{"username":"","password":""}' http://localhost:3000/api/register`
- `curl -s -X POST -H "Content-Type: application/json" -d '{"username":"user2","password":"pass"}' http://localhost:3000/api/login`

------
https://chatgpt.com/codex/tasks/task_e_68c313115264832bb6786846b69bca87