### PR TITLE
Improve API error handling for authentication routes

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -10,12 +10,22 @@ function hashPassword(password) {
 }
 
 async function register(username, password) {
+  if (!username || !password) {
+    throw new Error('Missing credentials');
+  }
+  const existing = await User.findOne({ where: { username } });
+  if (existing) {
+    throw new Error('User already exists');
+  }
   const password_hash = hashPassword(password);
   const user = await User.create({ username, password_hash });
   return { id: user.id, username: user.username };
 }
 
 async function login(username, password) {
+  if (!username || !password) {
+    throw new Error('Missing credentials');
+  }
   const user = await User.findOne({ where: { username } });
   if (!user) {
     throw new Error('Invalid credentials');

--- a/server/index.js
+++ b/server/index.js
@@ -1,31 +1,43 @@
 require('dotenv').config();
 const express = require('express');
+const path = require('path');
 const { sequelize, Trip } = require('./models');
 const { register, login, verifyToken } = require('./auth');
 
 const app = express();
 app.use(express.json());
-app.use(express.static('public'));
 
-app.post('/api/register', async (req, res) => {
-  const { username, password } = req.body;
-  try {
-    const user = await register(username, password);
-    res.status(201).json(user);
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-});
+app
+  .route('/api/register')
+  .post(async (req, res) => {
+    const { username, password } = req.body;
+    if (!username || !password) {
+      return res.status(400).json({ error: 'Faltan datos' });
+    }
+    try {
+      const user = await register(username, password);
+      res.status(201).json(user);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  })
+  .all((req, res) => res.status(405).json({ error: 'Método no permitido' }));
 
-app.post('/api/login', async (req, res) => {
-  const { username, password } = req.body;
-  try {
-    const token = await login(username, password);
-    res.json({ token });
-  } catch (err) {
-    res.status(401).json({ error: 'Credenciales inválidas' });
-  }
-});
+app
+  .route('/api/login')
+  .post(async (req, res) => {
+    const { username, password } = req.body;
+    if (!username || !password) {
+      return res.status(400).json({ error: 'Faltan datos' });
+    }
+    try {
+      const token = await login(username, password);
+      res.json({ token });
+    } catch (err) {
+      res.status(401).json({ error: 'Credenciales inválidas' });
+    }
+  })
+  .all((req, res) => res.status(405).json({ error: 'Método no permitido' }));
 
 app.post('/api/trips', verifyToken, async (req, res) => {
   const { country_code, visited_at } = req.body;
@@ -49,6 +61,14 @@ app.get('/api/trips', verifyToken, async (req, res) => {
     res.status(500).json({ error: err.message });
   }
 });
+
+// Return JSON 404 for unknown API routes
+app.use('/api', (req, res) => {
+  res.status(404).json({ error: 'Ruta no encontrada' });
+});
+
+// Serve static files after API routes so they don't override /api paths
+app.use(express.static(path.join(__dirname, '..', 'public')));
 
 const PORT = process.env.PORT || 3000;
 sequelize.sync().then(() => {


### PR DESCRIPTION
## Summary
- Respond 405 for unsupported methods on `/api/register` and `/api/login`
- Return JSON 404 for unknown API endpoints
- Serve static files using an absolute path

## Testing
- `npm test`
- `curl -i -H "Content-Type: application/json" -d '{"username":"user2","password":"pass"}' http://localhost:3000/api/register`
- `curl -i -H "Content-Type: application/json" -d '{"username":"user2","password":"pass"}' http://localhost:3000/api/login`


------
https://chatgpt.com/codex/tasks/task_e_68c313115264832bb6786846b69bca87