### PR TITLE
Reset session when token is invalid

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,7 @@
     <span id="username"></span>
     <button id="logoutBtn">Cerrar sesión</button>
   </nav>
+  <div id="message"></div>
   <div id="auth">
     <div id="authContainer">
       <div id="authSwitch">
@@ -34,7 +35,6 @@
         <button type="submit">Registrarse</button>
       </form>
     </div>
-    <div id="message"></div>
   </div>
   <div id="map" class="hidden"></div>
   <button id="addTripBtn" class="hidden">+</button>


### PR DESCRIPTION
## Summary
- Clear local session and refresh UI when API reports `401` in trip loading
- Remove saved token and force login when adding a trip fails with `401`
- Surface backend error messages when saving a trip fails
- Keep message banner visible after login so save errors are shown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c338e19714832b903c068c8e385e49