### PR TITLE
fix navbar layout and sqlite path for deployment

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2,6 +2,12 @@ html, body {
   height: 100%;
 }
 
+/* Ensure padding and borders are included in element widths to avoid
+   unwanted overflow that can push content off-screen on narrow viewports. */
+* {
+  box-sizing: border-box;
+}
+
 :root {
   --primary: #2563eb;
   --primary-hover: #1e4db7;
@@ -222,6 +228,7 @@ body.allow-scroll {
   align-items: center;
   justify-content: center;
   backdrop-filter: blur(2px);
+  z-index: 2000; /* Keep modal above navigation and floating buttons */
 }
 
 #dateModal:not(.hidden) {

--- a/server/auth.js
+++ b/server/auth.js
@@ -3,7 +3,10 @@ const crypto = require('crypto');
 const jwt = require('jsonwebtoken');
 const { User } = require('./models');
 
-const SECRET_KEY = process.env.JWT_SECRET;
+// Fallback to a default secret so authentication works even if the
+// environment variable isn't configured. This is primarily useful for
+// ephemeral environments like Vercel previews.
+const SECRET_KEY = process.env.JWT_SECRET || 'default-secret';
 
 function hashPassword(password) {
   return crypto.createHash('sha256').update(password).digest('hex');

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,9 +1,18 @@
 const { Sequelize, DataTypes } = require('sequelize');
+const path = require('path');
 
-// Initialize Sequelize with SQLite
+// Initialize Sequelize with SQLite. Allow the database location to be
+// configured via an environment variable so that deployments on
+// platforms with read-only filesystems (e.g. Vercel) can store the
+// SQLite file in a writable directory like `/tmp`.
+const defaultStorage =
+  process.env.NODE_ENV === 'production'
+    ? '/tmp/database.sqlite'
+    : path.join(__dirname, '..', 'database.sqlite');
+
 const sequelize = new Sequelize({
   dialect: 'sqlite',
-  storage: 'database.sqlite',
+  storage: process.env.DATABASE_PATH || defaultStorage,
   logging: false,
 });
 


### PR DESCRIPTION
## Summary
- prevent navbar overflow by using border-box sizing
- ensure date modal appears above other elements
- allow configuring SQLite storage path for deployment environments
- provide default JWT secret so login works without extra configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c344496654832b94954dd649c0a41a